### PR TITLE
[eamon]Search UI step2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
 # fe-w5-searchUI
-=======
-# fe-w3-shopping
->>>>>>> 3886578... Initial commit

--- a/shopping/public/javascripts/DOMselector.js
+++ b/shopping/public/javascripts/DOMselector.js
@@ -1,0 +1,17 @@
+import _ from "./utils.js";
+
+const body = _.$("body");
+const main = _.$(".main_section", body);
+const header = _.$("header", body);
+
+const $ = {
+  banner: _.$(".banner__right", main),
+  moreBtn: _.$(".more_contents", main),
+  moreContainer: _.$(".shoppinglists", main),
+  keyword: _.$(".header__keywords", header),
+  suggestionKeywords: _.$(".suggestionKeywords", header),
+  suggestion: _.$(".header__suggestion", header),
+  input: _.$("input", header),
+};
+
+export default $;

--- a/shopping/public/javascripts/SuggestionList.js
+++ b/shopping/public/javascripts/SuggestionList.js
@@ -1,0 +1,25 @@
+import _ from "./utils.js";
+
+const SuggestionList = function (List, ListParents) {
+  this.List = List.map((v) => v.keyword);
+  this.ListParents = ListParents;
+  this.length = this.List.length;
+};
+
+SuggestionList.prototype = {
+  init() {
+    this.List.forEach((v, index) => {
+      this.inserlist(this.ListParents, v, index);
+    });
+  },
+
+  inserlist(Parents, keyword, index) {
+    Parents.innerHTML += `<li><span class="num">${
+      index + 1
+    }.</span> ${keyword}</li>`;
+  },
+
+  constructor: SuggestionList,
+};
+
+export default SuggestionList;

--- a/shopping/public/javascripts/SuggestionList.js
+++ b/shopping/public/javascripts/SuggestionList.js
@@ -19,6 +19,7 @@ SuggestionList.prototype = {
     }.</span> ${keyword}</li>`;
   },
 
+
   constructor: SuggestionList,
 };
 

--- a/shopping/public/javascripts/SuggestionList.js
+++ b/shopping/public/javascripts/SuggestionList.js
@@ -8,17 +8,25 @@ const SuggestionList = function (List, ListParents) {
 
 SuggestionList.prototype = {
   init() {
-    this.List.forEach((v, index) => {
-      this.inserlist(this.ListParents, v, index);
-    });
+    this.insertHTML(this.ListParents);
   },
 
-  inserlist(Parents, keyword, index) {
-    Parents.innerHTML += `<li><span class="num">${
-      index + 1
-    }.</span> ${keyword}</li>`;
+  insertHTML(Parents) {
+    Parents.innerHTML = this.makeTitleHTML();
   },
 
+  makeListHTML(keyword,index){
+    return `<li><span class="num">${
+      index +1
+    }.</span> ${keyword}</li>`
+  },
+
+  makeTitleHTML() {
+    let listHTML = this.List.map((keyword,index) => this.makeListHTML(keyword,index))
+    .reduce((acc,curr)=> acc += curr);
+    return `<strong class="tit__suggestion">인기 쇼핑 키워드</strong>
+    <ol class="suggestion__items">` + listHTML +`</ol>`
+  },
 
   constructor: SuggestionList,
 };

--- a/shopping/public/javascripts/inputEvent.js
+++ b/shopping/public/javascripts/inputEvent.js
@@ -4,6 +4,7 @@ const inputEvent = function (input, suggestionList, rollingList) {
   this.input = input;
   this.suggestionList = suggestionList;
   this.rollingList = rollingList;
+  this.suggestionInner = _.$(".suggestionKeywords",suggestionList)
 };
 
 inputEvent.prototype = {
@@ -35,6 +36,18 @@ inputEvent.prototype = {
 
   inputEventHandler(value) {
     this.requestJsonp(value, "responseJsonpData");
+  },
+  insertHTML(Parents) {
+    Parents.innerHTML = this.makeTitleHTML();
+  },
+
+  makeListHTML(keyword){
+    return `<li class="itemList">${keyword}</li>`
+  },
+  
+
+  inputValue(value){
+    this.suggestionInner.innerHTML = value.map((keyword) => this.makeListHTML(keyword)).reduce((acc,cur) => acc += cur);
   },
 
   constructor: inputEvent,

--- a/shopping/public/javascripts/inputEvent.js
+++ b/shopping/public/javascripts/inputEvent.js
@@ -1,0 +1,31 @@
+import _ from "./utils.js";
+
+const inputEvent = function (input, suggestionList, rollingList) {
+  this.input = input;
+  this.suggestionList = suggestionList;
+  this.rollingList = rollingList;
+};
+
+inputEvent.prototype = {
+  init() {
+    this.onEvent();
+  },
+
+  onEvent() {
+    _.on(this.input, "focusin", () =>
+      this.FocusEventHandler(this.suggestionList, this.rollingList)
+    );
+    _.on(this.input, "focusout", () =>
+      this.FocusEventHandler(this.rollingList, this.suggestionList)
+    );
+  },
+
+  FocusEventHandler(target1, target2) {
+    _.remove(target1, "none");
+    _.add(target2, "none");
+  },
+
+  constructor: inputEvent,
+};
+
+export default inputEvent;

--- a/shopping/public/javascripts/inputEvent.js
+++ b/shopping/public/javascripts/inputEvent.js
@@ -18,11 +18,23 @@ inputEvent.prototype = {
     _.on(this.input, "focusout", () =>
       this.FocusEventHandler(this.rollingList, this.suggestionList)
     );
+    _.on(this.input, "input", ({ target }) =>
+      this.inputEventHandler(target.value)
+    );
   },
 
   FocusEventHandler(target1, target2) {
     _.remove(target1, "none");
     _.add(target2, "none");
+  },
+  requestJsonp(word, callback) {
+    const script = document.createElement("script");
+    script.src = `https://suggest-bar.daum.net/suggest?callback=${callback}&limit=10&mode=json&code=utf_in_out&q=${word}&id=shoppinghow_suggest`;
+    document.body.append(script);
+  },
+
+  inputEventHandler(value) {
+    this.requestJsonp(value, "responseJsonpData");
   },
 
   constructor: inputEvent,

--- a/shopping/public/javascripts/main.js
+++ b/shopping/public/javascripts/main.js
@@ -21,7 +21,8 @@ slider.init();
 inputevent.init();
 
 window["responseJsonpData"] = function (data) {
-  console.log(data.items);
+  
+  inputevent.inputValue(data.items.map((value) => value.substr(0, value.length-2)));
 };
 
 fetch("http://localhost:3000/moreItem.json")

--- a/shopping/public/javascripts/main.js
+++ b/shopping/public/javascripts/main.js
@@ -2,18 +2,22 @@ import Slider from "./slider.js";
 import Morebtn from "./more.js";
 import RollingList from "./rollingList.js";
 import SuggestionList from "./SuggestionList.js";
+import inputEvent from "./inputEvent.js";
 import _ from "./utils.js";
-const main = _.$(".main_section");
+const body = _.$("body");
+const main = _.$(".main_section", body);
+const header = _.$("header", body);
 const banner = _.$(".banner__right", main);
 const $moreBtn = _.$(".more_contents", main);
 const $moreContainer = _.$(".shoppinglists", main);
-const $keyword = _.$(".header__keywords");
-const $suggestionItems = _.$(".suggestion__items");
+const $keyword = _.$(".header__keywords", header);
+const $suggestionItems = _.$(".suggestion__items", header);
+const $suggestion = _.$(".header__suggestion", header);
+const $input = _.$("input", header);
 const slider = new Slider(banner);
+const inputevent = new inputEvent($input, $suggestion, $keyword);
 
-fetch("http://localhost:3000/moreItem.json");
-
-let item = fetch("http://localhost:3000/moreItem.json")
+fetch("http://localhost:3000/moreItem.json")
   .then((res) => res.json())
   .then((json) => {
     const morebtn = new Morebtn(json.mallEventList, $moreBtn, $moreContainer);
@@ -32,3 +36,4 @@ fetch(
   });
 
 slider.init();
+inputevent.init();

--- a/shopping/public/javascripts/main.js
+++ b/shopping/public/javascripts/main.js
@@ -1,16 +1,17 @@
 import Slider from "./slider.js";
 import Morebtn from "./more.js";
+import RollingList from "./rollingList.js";
 import _ from "./utils.js";
 const main = _.$(".main_section");
 const banner = _.$(".banner__right", main);
 const $moreBtn = _.$(".more_contents", main);
 const $moreContainer = _.$(".shoppinglists", main);
+const $keyword = _.$(".header__keywords");
 const slider = new Slider(banner);
 
-fetch("http://localhost:3000/moreItem.json")
+fetch("http://localhost:3000/moreItem.json");
 
 let item = fetch("http://localhost:3000/moreItem.json")
-
   .then((res) => res.json())
   .then((json) => {
     const morebtn = new Morebtn(json.mallEventList, $moreBtn, $moreContainer);
@@ -21,11 +22,9 @@ fetch(
   "https://shoppinghow.kakao.com/v1.0/shophow/top/recomKeyword.json?_=1615183888074"
 )
   .then((data) => new Promise((res) => res(data.json()))) //
-  .then((d)=> console.log(d.list));
-
-console.log("help");
-
-
+  .then((d) => {
+    const _rollinglist = new RollingList(d.list, $keyword);
+    _rollinglist.init();
+  });
 
 slider.init();
-

--- a/shopping/public/javascripts/main.js
+++ b/shopping/public/javascripts/main.js
@@ -1,12 +1,14 @@
 import Slider from "./slider.js";
 import Morebtn from "./more.js";
 import RollingList from "./rollingList.js";
+import SuggestionList from "./SuggestionList.js";
 import _ from "./utils.js";
 const main = _.$(".main_section");
 const banner = _.$(".banner__right", main);
 const $moreBtn = _.$(".more_contents", main);
 const $moreContainer = _.$(".shoppinglists", main);
 const $keyword = _.$(".header__keywords");
+const $suggestionItems = _.$(".suggestion__items");
 const slider = new Slider(banner);
 
 fetch("http://localhost:3000/moreItem.json");
@@ -24,7 +26,9 @@ fetch(
   .then((data) => new Promise((res) => res(data.json()))) //
   .then((d) => {
     const _rollinglist = new RollingList(d.list, $keyword);
+    const _suggestionlist = new SuggestionList(d.list, $suggestionItems);
     _rollinglist.init();
+    _suggestionlist.init();
   });
 
 slider.init();

--- a/shopping/public/javascripts/main.js
+++ b/shopping/public/javascripts/main.js
@@ -4,18 +4,9 @@ import RollingList from "./rollingList.js";
 import SuggestionList from "./SuggestionList.js";
 import inputEvent from "./inputEvent.js";
 import _ from "./utils.js";
-const body = _.$("body");
-const main = _.$(".main_section", body);
-const header = _.$("header", body);
-const banner = _.$(".banner__right", main);
-const $moreBtn = _.$(".more_contents", main);
-const $moreContainer = _.$(".shoppinglists", main);
-const $keyword = _.$(".header__keywords", header);
-const $suggestionKeywords = _.$(".suggestionKeywords", header);
-const $suggestion = _.$(".header__suggestion", header);
-const $input = _.$("input", header);
-const slider = new Slider(banner);
-const inputevent = new inputEvent($input, $suggestion, $keyword);
+import $ from "./DOMselector.js";
+const slider = new Slider($.banner);
+const inputevent = new inputEvent($.input, $.suggestion, $.keyword);
 
 slider.init();
 inputevent.init();
@@ -28,7 +19,7 @@ window["responseJsonpData"] = function (data) {
 fetch("http://localhost:3000/moreItem.json")
   .then((res) => res.json())
   .then((json) => {
-    const morebtn = new Morebtn(json.mallEventList, $moreBtn, $moreContainer);
+    const morebtn = new Morebtn(json.mallEventList, $.moreBtn, $.moreContainer);
     morebtn.init();
   });
 
@@ -37,8 +28,8 @@ fetch(
 )
   .then((data) => new Promise((res) => res(data.json()))) //
   .then((d) => {
-    const _rollinglist = new RollingList(d.list, $keyword);
-    const _suggestionlist = new SuggestionList(d.list, $suggestionKeywords);
+    const _rollinglist = new RollingList(d.list, $.keyword);
+    const _suggestionlist = new SuggestionList(d.list, $.suggestionKeywords);
     _rollinglist.init();
     _suggestionlist.init();
   });

--- a/shopping/public/javascripts/main.js
+++ b/shopping/public/javascripts/main.js
@@ -11,11 +11,18 @@ const banner = _.$(".banner__right", main);
 const $moreBtn = _.$(".more_contents", main);
 const $moreContainer = _.$(".shoppinglists", main);
 const $keyword = _.$(".header__keywords", header);
-const $suggestionItems = _.$(".suggestion__items", header);
+const $suggestionKeywords = _.$(".suggestionKeywords", header);
 const $suggestion = _.$(".header__suggestion", header);
 const $input = _.$("input", header);
 const slider = new Slider(banner);
 const inputevent = new inputEvent($input, $suggestion, $keyword);
+
+slider.init();
+inputevent.init();
+
+window["responseJsonpData"] = function (data) {
+  console.log(data.items);
+};
 
 fetch("http://localhost:3000/moreItem.json")
   .then((res) => res.json())
@@ -30,10 +37,7 @@ fetch(
   .then((data) => new Promise((res) => res(data.json()))) //
   .then((d) => {
     const _rollinglist = new RollingList(d.list, $keyword);
-    const _suggestionlist = new SuggestionList(d.list, $suggestionItems);
+    const _suggestionlist = new SuggestionList(d.list, $suggestionKeywords);
     _rollinglist.init();
     _suggestionlist.init();
   });
-
-slider.init();
-inputevent.init();

--- a/shopping/public/javascripts/more.js
+++ b/shopping/public/javascripts/more.js
@@ -1,12 +1,5 @@
 import _ from "./utils.js";
-<<<<<<< HEAD
-<<<<<<< HEAD
 import listHTML from "./HtmlTemplete.js";
-=======
->>>>>>> 63d9730... [FEAT]make Morebtn class
-=======
-import listHTML from "./HtmlTemplete.js";
->>>>>>> 1931f10... [FEAT]Add moreBtn 기능 구
 
 export default class Morebtn {
   constructor(data, moreBtn, container) {
@@ -14,40 +7,23 @@ export default class Morebtn {
     this.totalData = data.length;
     this.container = container;
     this.moreBtn = moreBtn;
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 1931f10... [FEAT]Add moreBtn 기능 구
     this.currentIndex = 0;
   }
 
   init() {
-    this.splitedData = this.splitData(4);
-<<<<<<< HEAD
-=======
-  }
-
-  init() {
->>>>>>> 63d9730... [FEAT]make Morebtn class
-=======
->>>>>>> 1931f10... [FEAT]Add moreBtn 기능 구
     this.clickEvent();
   }
 
   clickEvent() {
     _.on(this.moreBtn, "click", this.clickHandler.bind(this));
   }
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 1931f10... [FEAT]Add moreBtn 기능 구
+
   makeHTML() {
     return this.splitedData[this.currentIndex].reduce(
       (acc, cur) => acc + listHTML(cur.imgurl, cur.text, cur.text2),
       ""
     );
   }
-<<<<<<< HEAD
 
   render() {
     this.container.innerHTML += this.makeHTML();
@@ -63,28 +39,5 @@ export default class Morebtn {
       splitedData.push(this.data.slice(i, i + num));
     }
     return splitedData;
-=======
-=======
->>>>>>> 1931f10... [FEAT]Add moreBtn 기능 구
-
-  render() {
-    this.container.innerHTML += this.makeHTML();
-  }
-
-  clickHandler() {
-<<<<<<< HEAD
-    console.log(this.data[0]);
->>>>>>> 63d9730... [FEAT]make Morebtn class
-=======
-    this.currentIndex += 1;
-    this.render();
-  }
-  splitData(num) {
-    let splitedData = [];
-    for (let i = 0; i < this.totalData; i += num) {
-      splitedData.push(this.data.slice(i, i + num));
-    }
-    return splitedData;
->>>>>>> 1931f10... [FEAT]Add moreBtn 기능 구
   }
 }

--- a/shopping/public/javascripts/rollingList.js
+++ b/shopping/public/javascripts/rollingList.js
@@ -1,14 +1,18 @@
-const rolingList = function (List, ListParents) {
+const RolingList = function (List, ListParents) {
   this.List = List.map((v) => v.keyword);
   this.ListParents = ListParents;
 };
 
-rolingList.prototype.init = function () {
-  this.List.forEach((v) => this.inserlist(this.ListParents, v));
+RolingList.prototype.init = function () {
+  this.List.forEach((v, index) => {
+    
+    this.inserlist(this.ListParents, v, index);
+  });
 };
 
-rolingList.prototype.inserlist = function (Parents, keyword) {
-  Parents.innerHTML = `<li>${keyword}</li>`;
+RolingList.prototype.inserlist = function (Parents, keyword, index) {
+let currHTML = Parents.innerHTML;
+  Parents.innerHTML = currHTML + `<li>${index+1}. ${keyword}</li>`;
 };
 
-export default rolingList;
+export default RolingList;

--- a/shopping/public/javascripts/rollingList.js
+++ b/shopping/public/javascripts/rollingList.js
@@ -1,0 +1,14 @@
+const rolingList = function (List, ListParents) {
+  this.List = List.map((v) => v.keyword);
+  this.ListParents = ListParents;
+};
+
+rolingList.prototype.init = function () {
+  this.List.forEach((v) => this.inserlist(this.ListParents, v));
+};
+
+rolingList.prototype.inserlist = function (Parents, keyword) {
+  Parents.innerHTML = `<li>${keyword}</li>`;
+};
+
+export default rolingList;

--- a/shopping/public/javascripts/rollingList.js
+++ b/shopping/public/javascripts/rollingList.js
@@ -10,7 +10,7 @@ RolingList.prototype.init = function () {
   this.List.forEach((v, index) => {
     this.inserlist(this.ListParents, v, index);
   });
-  this.ListParents.style.transitionDuration = `1s`;
+  this.inserlist(this.ListParents, this.List[0], 0);
   this.ListParents.style.transform = `translateY(${this.height}px)`;
   this.setinterval(1500, this.length);
 };
@@ -28,24 +28,22 @@ RolingList.prototype.silde = function (height) {
   this.ListParents.style.transform = `translateY(${height + currHeight}px)`;
 };
 RolingList.prototype.setintervalFinish = async function () {
-    this.ListParents.style.transition = `none`;
-    this.ListParents.style.transform = `translateY(0px)`;
-    await _.delay(1500);
-    debugger;
-    this.ListParents.style.transitionDuration = `1s`;
-    this.ListParents.style.transform = `translateY(${this.height}px)`;
-    this.setinterval(1500, this.length);
-  };
+  this.ListParents.style.transition = `none`;
+  this.ListParents.style.transform = `translateY(0px)`;
+  await _.delay(500);
+  this.ListParents.removeAttribute("style");
+  this.ListParents.style.transform = `translateY(${this.height}px)`;
+  this.setinterval(1500, this.length);
+};
 
 RolingList.prototype.setinterval = async function (Time, length) {
-  for (let i = 0; i < length - 2; i++) {
+  for (let i = 0; i < length; i++) {
     await _.delay(Time);
     this.silde(this.height);
-    if (i === length - 3) {
+    if (i === length - 1) {
       this.setintervalFinish();
     }
   }
-
 };
 
 export default RolingList;

--- a/shopping/public/javascripts/rollingList.js
+++ b/shopping/public/javascripts/rollingList.js
@@ -16,8 +16,7 @@ RolingList.prototype.init = function () {
 };
 
 RolingList.prototype.inserlist = function (Parents, keyword, index) {
-  let currHTML = Parents.innerHTML;
-  Parents.innerHTML = currHTML + `<li>${index + 1}. ${keyword}</li>`;
+  Parents.innerHTML += `<li>${index + 1}. ${keyword}</li>`;
 };
 
 RolingList.prototype.silde = function (height) {

--- a/shopping/public/javascripts/rollingList.js
+++ b/shopping/public/javascripts/rollingList.js
@@ -1,18 +1,51 @@
+import _ from "./utils.js";
 const RolingList = function (List, ListParents) {
   this.List = List.map((v) => v.keyword);
   this.ListParents = ListParents;
+  this.length = this.List.length;
+  this.height = -38;
 };
 
 RolingList.prototype.init = function () {
   this.List.forEach((v, index) => {
-    
     this.inserlist(this.ListParents, v, index);
   });
+  this.ListParents.style.transitionDuration = `1s`;
+  this.ListParents.style.transform = `translateY(${this.height}px)`;
+  this.setinterval(1500, this.length);
 };
 
 RolingList.prototype.inserlist = function (Parents, keyword, index) {
-let currHTML = Parents.innerHTML;
-  Parents.innerHTML = currHTML + `<li>${index+1}. ${keyword}</li>`;
+  let currHTML = Parents.innerHTML;
+  Parents.innerHTML = currHTML + `<li>${index + 1}. ${keyword}</li>`;
+};
+
+RolingList.prototype.silde = function (height) {
+  let currHeight = parseInt(
+    this.ListParents.style.transform.replace(/[a-z()]/gi, "")
+  );
+
+  this.ListParents.style.transform = `translateY(${height + currHeight}px)`;
+};
+RolingList.prototype.setintervalFinish = async function () {
+    this.ListParents.style.transition = `none`;
+    this.ListParents.style.transform = `translateY(0px)`;
+    await _.delay(1500);
+    debugger;
+    this.ListParents.style.transitionDuration = `1s`;
+    this.ListParents.style.transform = `translateY(${this.height}px)`;
+    this.setinterval(1500, this.length);
+  };
+
+RolingList.prototype.setinterval = async function (Time, length) {
+  for (let i = 0; i < length - 2; i++) {
+    await _.delay(Time);
+    this.silde(this.height);
+    if (i === length - 3) {
+      this.setintervalFinish();
+    }
+  }
+
 };
 
 export default RolingList;

--- a/shopping/public/javascripts/utils.js
+++ b/shopping/public/javascripts/utils.js
@@ -1,18 +1,19 @@
 const _ = {
-    add: (target, className) => target.classList.add(className),
-  
-    remove: (target, className) => target.classList.remove(className),
-  
-   toggle: (target, className) => target.classList.toggle(className),
-    
-    replace: (target, oldClassName, newClassName) =>
-      target.classList.replace(oldClassName, newClassName),
-    $: (selector, base = document) => base.querySelector(selector),
-  
-    $A: (selector, base = document) => base.querySelectorAll(selector),
-  
-    on: (target, type, listener, useCapture = false) =>
-      target.addEventListener(type, listener, useCapture),
-  };
-  
-  export default _;
+  add: (target, className) => target.classList.add(className),
+
+  remove: (target, className) => target.classList.remove(className),
+
+  toggle: (target, className) => target.classList.toggle(className),
+
+  replace: (target, oldClassName, newClassName) =>
+    target.classList.replace(oldClassName, newClassName),
+  $: (selector, base = document) => base.querySelector(selector),
+
+  $A: (selector, base = document) => base.querySelectorAll(selector),
+
+  on: (target, type, listener, useCapture = false) =>
+    target.addEventListener(type, listener, useCapture),
+  delay: (time) => new Promise((resolve) => setTimeout(() => resolve(), time)),
+};
+
+export default _;

--- a/shopping/public/javascripts/utils.js
+++ b/shopping/public/javascripts/utils.js
@@ -13,6 +13,7 @@ const _ = {
 
   on: (target, type, listener, useCapture = false) =>
     target.addEventListener(type, listener, useCapture),
+    
   delay: (time) => new Promise((resolve) => setTimeout(() => resolve(), time)),
 };
 

--- a/shopping/public/stylesheets/components/componet.css
+++ b/shopping/public/stylesheets/components/componet.css
@@ -58,3 +58,6 @@
     display: block;
     color: #888;
     font-size: 12px; }
+
+.none {
+  visibility: hidden; }

--- a/shopping/public/stylesheets/header/header.css
+++ b/shopping/public/stylesheets/header/header.css
@@ -124,10 +124,9 @@ header {
 
 .header__suggestion {
   position: absolute;
-  padding: 25px 29px 23px;
   overflow: hidden;
-  left: 364px;
-  top: 109px;
+  left: 360px;
+  top: 97px;
   z-index: 10;
   width: 670px;
   border: 1px solid #f95139;
@@ -135,23 +134,25 @@ header {
   background-color: #fff;
   box-sizing: border-box;
   text-align: left; }
-  .header__suggestion strong {
-    display: block;
-    padding-bottom: 5px;
-    font-size: 16px;
-    color: #a6a6a6;
-    letter-spacing: -.04em; }
-  .header__suggestion ol {
-    display: grid;
-    grid-template-columns: 1fr 1fr; }
-    .header__suggestion ol li {
-      font-size: 14px;
-      letter-spacing: -.05em;
-      color: #222;
-      height: 21px;
-      padding: 12px 15px 0 0;
-      text-overflow: ellipsis;
-      white-space: nowrap; }
+  .header__suggestion div {
+    padding: 25px 29px 23px; }
+    .header__suggestion div strong {
+      display: block;
+      padding-bottom: 5px;
+      font-size: 16px;
+      color: #a6a6a6;
+      letter-spacing: -.04em; }
+    .header__suggestion div ol {
+      display: grid;
+      grid-template-columns: 1fr 1fr; }
+      .header__suggestion div ol li {
+        font-size: 14px;
+        letter-spacing: -.05em;
+        color: #222;
+        height: 21px;
+        padding: 12px 15px 0 0;
+        text-overflow: ellipsis;
+        white-space: nowrap; }
 
 .num {
   margin-right: 10px;

--- a/shopping/public/stylesheets/header/header.css
+++ b/shopping/public/stylesheets/header/header.css
@@ -22,7 +22,7 @@ header {
       margin: 0 24px 0 30px;
       width: 670px;
       height: 54px;
-      padding: 16px 60px 14px 30px;
+      padding: 16px 60px 16px 30px;
       border: 1px solid #cecfd1;
       border-radius: 10px;
       background-color: #fff;
@@ -98,7 +98,9 @@ header {
     background-position: 0 -30px; }
 
 .header__keywords {
-  top: 4px;
+  transition-duration: 1s;
+  transform: translateY(0px);
+  top: 0px;
   position: absolute;
   left: 155px; }
   .header__keywords li {
@@ -111,4 +113,4 @@ header {
     text-overflow: ellipsis;
     white-space: nowrap;
     text-align: left;
-    margin: 15px; }
+    margin: 16px; }

--- a/shopping/public/stylesheets/header/header.css
+++ b/shopping/public/stylesheets/header/header.css
@@ -114,3 +114,39 @@ header {
     white-space: nowrap;
     text-align: left;
     margin: 16px; }
+
+.header__suggestion {
+  position: absolute;
+  padding: 25px 29px 23px;
+  overflow: hidden;
+  left: 327px;
+  top: 109px;
+  z-index: 10;
+  width: 670px;
+  border: 1px solid #f95139;
+  border-radius: 10px;
+  background-color: #fff;
+  box-sizing: border-box;
+  text-align: left; }
+  .header__suggestion strong {
+    display: block;
+    padding-bottom: 5px;
+    font-size: 16px;
+    color: #a6a6a6;
+    letter-spacing: -.04em; }
+  .header__suggestion ol {
+    display: grid;
+    grid-template-columns: 1fr 1fr; }
+    .header__suggestion ol li {
+      font-size: 14px;
+      letter-spacing: -.05em;
+      color: #222;
+      height: 21px;
+      padding: 12px 15px 0 0;
+      text-overflow: ellipsis;
+      white-space: nowrap; }
+
+.num {
+  margin-right: 10px;
+  font-weight: 700;
+  font-family: robotoitalic,Apple SD Gothic Neo,Malgun Gothic,맑은 고딕,Dotum,돋움,sans-serif; }

--- a/shopping/public/stylesheets/header/header.css
+++ b/shopping/public/stylesheets/header/header.css
@@ -9,7 +9,9 @@ header {
 
 .header__searchbar {
   display: inline-block;
-  vertical-align: top; }
+  vertical-align: top;
+  overflow-y: hidden;
+  position: relative; }
   .header__searchbar img {
     width: 119px;
     height: auto; }
@@ -96,10 +98,9 @@ header {
     background-position: 0 -30px; }
 
 .header__keywords {
+  top: 4px;
   position: absolute;
-  top: 47px;
-  position: absolute;
-  left: 328px; }
+  left: 155px; }
   .header__keywords li {
     overflow: hidden;
     height: 22px;

--- a/shopping/public/stylesheets/header/header.css
+++ b/shopping/public/stylesheets/header/header.css
@@ -158,3 +158,15 @@ header {
   margin-right: 10px;
   font-weight: 700;
   font-family: robotoitalic,Apple SD Gothic Neo,Malgun Gothic,맑은 고딕,Dotum,돋움,sans-serif; }
+
+.itemList {
+  display: block;
+  overflow: hidden;
+  height: 26px;
+  padding: 0 29px;
+  line-height: 26px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+  letter-spacing: -.05em;
+  color: #222; }

--- a/shopping/public/stylesheets/header/header.css
+++ b/shopping/public/stylesheets/header/header.css
@@ -13,16 +13,18 @@ header {
   .header__searchbar img {
     width: 119px;
     height: auto; }
-  .header__searchbar input {
-    float: right;
-    margin: 0 24px 0 30px;
-    width: 670px;
-    height: 54px;
-    padding: 16px 60px 14px 30px;
-    border: 1px solid #cecfd1;
-    border-radius: 10px;
-    background-color: #fff;
-    box-sizing: border-box; }
+  .header__searchbar div {
+    float: right; }
+    .header__searchbar div input {
+      float: right;
+      margin: 0 24px 0 30px;
+      width: 670px;
+      height: 54px;
+      padding: 16px 60px 14px 30px;
+      border: 1px solid #cecfd1;
+      border-radius: 10px;
+      background-color: #fff;
+      box-sizing: border-box; }
 
 .header__navbar {
   box-sizing: border-box;
@@ -92,3 +94,20 @@ header {
   .header__navbar__catagory .ico_menu {
     left: 4px;
     background-position: 0 -30px; }
+
+.header__keywords {
+  position: absolute;
+  top: 47px;
+  position: absolute;
+  left: 328px; }
+  .header__keywords li {
+    overflow: hidden;
+    height: 22px;
+    font-weight: 700;
+    font-size: 20px;
+    line-height: 22px;
+    color: #939393;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
+    margin: 15px; }

--- a/shopping/public/stylesheets/header/header.css
+++ b/shopping/public/stylesheets/header/header.css
@@ -20,13 +20,19 @@ header {
     .header__searchbar div input {
       float: right;
       margin: 0 24px 0 30px;
+      position: relative;
+      z-index: 3;
       width: 670px;
       height: 54px;
       padding: 16px 60px 16px 30px;
       border: 1px solid #cecfd1;
       border-radius: 10px;
-      background-color: #fff;
+      background-color: transparent;
       box-sizing: border-box; }
+      .header__searchbar div input:focus {
+        outline: none;
+        border: 1px solid #f95139;
+        border-radius: 10px; }
 
 .header__navbar {
   box-sizing: border-box;
@@ -102,7 +108,8 @@ header {
   transform: translateY(0px);
   top: 0px;
   position: absolute;
-  left: 155px; }
+  left: 155px;
+  z-index: 2; }
   .header__keywords li {
     overflow: hidden;
     height: 22px;
@@ -119,7 +126,7 @@ header {
   position: absolute;
   padding: 25px 29px 23px;
   overflow: hidden;
-  left: 327px;
+  left: 364px;
   top: 109px;
   z-index: 10;
   width: 670px;

--- a/shopping/public/stylesheets/reset.css
+++ b/shopping/public/stylesheets/reset.css
@@ -133,3 +133,7 @@ button {
   cursor: pointer;
   border-radius: 0;
 }
+
+li{
+  list-style: none;;
+}

--- a/shopping/public/stylesheets/sass/components/componet.sass
+++ b/shopping/public/stylesheets/sass/components/componet.sass
@@ -58,3 +58,5 @@ $--list-border: 1px solid rgba(0, 0, 0,0.05)
         display: block
         color: #888
         font-size: 12px
+.none
+    visibility: hidden

--- a/shopping/public/stylesheets/sass/header/header.sass
+++ b/shopping/public/stylesheets/sass/header/header.sass
@@ -126,10 +126,9 @@ header
 
 .header__suggestion
     position: absolute
-    padding: 25px 29px 23px
     overflow: hidden
-    left: 364px
-    top: 109px
+    left: 360px
+    top: 97px
     z-index: 10
     width: 670px
     border: 1px solid #f95139
@@ -137,24 +136,26 @@ header
     background-color: #fff
     box-sizing: border-box
     text-align: left
-    strong
-        display: block
-        padding-bottom: 5px
-        font-size: 16px
-        color: #a6a6a6
-        letter-spacing: -.04em
-    ol
-        display: grid
-        grid-template-columns: 1fr 1fr
+    div
+        padding: 25px 29px 23px
+        strong
+            display: block
+            padding-bottom: 5px
+            font-size: 16px
+            color: #a6a6a6
+            letter-spacing: -.04em
+        ol
+            display: grid
+            grid-template-columns: 1fr 1fr
 
-        li
-            font-size: 14px
-            letter-spacing: -.05em
-            color: #222
-            height: 21px
-            padding: 12px 15px 0 0
-            text-overflow: ellipsis
-            white-space: nowrap
+            li
+                font-size: 14px
+                letter-spacing: -.05em
+                color: #222
+                height: 21px
+                padding: 12px 15px 0 0
+                text-overflow: ellipsis
+                white-space: nowrap
 
 .num
     margin-right: 10px

--- a/shopping/public/stylesheets/sass/header/header.sass
+++ b/shopping/public/stylesheets/sass/header/header.sass
@@ -9,6 +9,8 @@ header
 .header__searchbar
     display: inline-block
     vertical-align: top
+    overflow-y: hidden
+    position: relative
 
     img
         width: 119px
@@ -98,10 +100,9 @@ header
         background-position: 0 -30px
 
 .header__keywords
+    top: 4px
     position: absolute
-    top: 47px
-    position: absolute
-    left: 328px
+    left: 155px
     li
         overflow: hidden
         height: 22px
@@ -112,4 +113,4 @@ header
         text-overflow: ellipsis
         white-space: nowrap
         text-align: left
-        margin: 15px 
+        margin: 15px

--- a/shopping/public/stylesheets/sass/header/header.sass
+++ b/shopping/public/stylesheets/sass/header/header.sass
@@ -13,16 +13,18 @@ header
     img
         width: 119px
         height: auto
-    input
+    div
         float: right
-        margin: 0 24px 0 30px
-        width: 670px
-        height: 54px
-        padding: 16px 60px 14px 30px
-        border: 1px solid #cecfd1
-        border-radius: 10px
-        background-color: #fff
-        box-sizing: border-box
+        input
+            float: right
+            margin: 0 24px 0 30px
+            width: 670px
+            height: 54px
+            padding: 16px 60px 14px 30px
+            border: 1px solid #cecfd1
+            border-radius: 10px
+            background-color: #fff
+            box-sizing: border-box
 
 .header__navbar
     box-sizing: border-box
@@ -59,7 +61,7 @@ header
 .header__navbar__login
     float: right
     position: relative
-    text-align: left;
+    text-align: left
     .ico_user
         left: 0
         background-position: -30px -30px
@@ -72,7 +74,7 @@ header
     width: 90px
     padding: 0 16px 0 34px
     position: relative
-    text-align: left;
+    text-align: left
 
     .ico_products
         left: 0
@@ -87,10 +89,27 @@ header
 
 .header__navbar__catagory
     position: relative
-    text-align: left;
+    text-align: left
     width: 82px
     height: 54px
     padding-left: 40px
     .ico_menu
         left: 4px
         background-position: 0 -30px
+
+.header__keywords
+    position: absolute
+    top: 47px
+    position: absolute
+    left: 328px
+    li
+        overflow: hidden
+        height: 22px
+        font-weight: 700
+        font-size: 20px
+        line-height: 22px
+        color: #939393
+        text-overflow: ellipsis
+        white-space: nowrap
+        text-align: left
+        margin: 15px 

--- a/shopping/public/stylesheets/sass/header/header.sass
+++ b/shopping/public/stylesheets/sass/header/header.sass
@@ -22,7 +22,7 @@ header
             margin: 0 24px 0 30px
             width: 670px
             height: 54px
-            padding: 16px 60px 14px 30px
+            padding: 16px 60px 16px 30px
             border: 1px solid #cecfd1
             border-radius: 10px
             background-color: #fff
@@ -100,7 +100,9 @@ header
         background-position: 0 -30px
 
 .header__keywords
-    top: 4px
+    transition-duration: 1s
+    transform: translateY(0px)
+    top: 0px
     position: absolute
     left: 155px
     li
@@ -113,4 +115,4 @@ header
         text-overflow: ellipsis
         white-space: nowrap
         text-align: left
-        margin: 15px
+        margin: 16px

--- a/shopping/public/stylesheets/sass/header/header.sass
+++ b/shopping/public/stylesheets/sass/header/header.sass
@@ -161,3 +161,15 @@ header
     margin-right: 10px
     font-weight: 700
     font-family: robotoitalic,Apple SD Gothic Neo,Malgun Gothic,맑은 고딕,Dotum,돋움,sans-serif
+
+.itemList
+    display: block
+    overflow: hidden
+    height: 26px
+    padding: 0 29px
+    line-height: 26px
+    text-overflow: ellipsis
+    white-space: nowrap
+    font-size: 14px
+    letter-spacing: -.05em
+    color: #222

--- a/shopping/public/stylesheets/sass/header/header.sass
+++ b/shopping/public/stylesheets/sass/header/header.sass
@@ -116,3 +116,40 @@ header
         white-space: nowrap
         text-align: left
         margin: 16px
+
+.header__suggestion
+    position: absolute
+    padding: 25px 29px 23px
+    overflow: hidden
+    left: 327px
+    top: 109px
+    z-index: 10
+    width: 670px
+    border: 1px solid #f95139
+    border-radius: 10px
+    background-color: #fff
+    box-sizing: border-box
+    text-align: left
+    strong
+        display: block
+        padding-bottom: 5px
+        font-size: 16px
+        color: #a6a6a6
+        letter-spacing: -.04em
+    ol
+        display: grid
+        grid-template-columns: 1fr 1fr
+
+        li
+            font-size: 14px
+            letter-spacing: -.05em
+            color: #222
+            height: 21px
+            padding: 12px 15px 0 0
+            text-overflow: ellipsis
+            white-space: nowrap
+
+.num
+    margin-right: 10px
+    font-weight: 700
+    font-family: robotoitalic,Apple SD Gothic Neo,Malgun Gothic,맑은 고딕,Dotum,돋움,sans-serif

--- a/shopping/public/stylesheets/sass/header/header.sass
+++ b/shopping/public/stylesheets/sass/header/header.sass
@@ -20,13 +20,19 @@ header
         input
             float: right
             margin: 0 24px 0 30px
+            position: relative
+            z-index: 3
             width: 670px
             height: 54px
             padding: 16px 60px 16px 30px
             border: 1px solid #cecfd1
             border-radius: 10px
-            background-color: #fff
+            background-color: transparent
             box-sizing: border-box
+            &:focus
+                outline: none
+                border: 1px solid #f95139
+                border-radius: 10px
 
 .header__navbar
     box-sizing: border-box
@@ -105,6 +111,7 @@ header
     top: 0px
     position: absolute
     left: 155px
+    z-index: 2
     li
         overflow: hidden
         height: 22px
@@ -121,7 +128,7 @@ header
     position: absolute
     padding: 25px 29px 23px
     overflow: hidden
-    left: 327px
+    left: 364px
     top: 109px
     z-index: 10
     width: 670px

--- a/shopping/public/stylesheets/style.css
+++ b/shopping/public/stylesheets/style.css
@@ -83,7 +83,7 @@ header {
       margin: 0 24px 0 30px;
       width: 670px;
       height: 54px;
-      padding: 16px 60px 14px 30px;
+      padding: 16px 60px 16px 30px;
       border: 1px solid #cecfd1;
       border-radius: 10px;
       background-color: #fff;
@@ -159,7 +159,9 @@ header {
     background-position: 0 -30px; }
 
 .header__keywords {
-  top: 4px;
+  transition-duration: 1s;
+  transform: translateY(0px);
+  top: 0px;
   position: absolute;
   left: 155px; }
   .header__keywords li {
@@ -172,7 +174,7 @@ header {
     text-overflow: ellipsis;
     white-space: nowrap;
     text-align: left;
-    margin: 15px; }
+    margin: 16px; }
 
 .main__banner {
   overflow: hidden;

--- a/shopping/public/stylesheets/style.css
+++ b/shopping/public/stylesheets/style.css
@@ -1,22 +1,18 @@
 @charset "UTF-8";
 .layer1 {
-  z-index: 1;
-}
+  z-index: 1; }
 
 .layer2 {
-  z-index: -1;
-}
+  z-index: -1; }
 
 .icon {
-  background: url(//shop1.daumcdn.net/search/cdn/simage/shopping/v2/common/nav/ico_gnb_shw.png)
-    no-repeat;
+  background: url(//shop1.daumcdn.net/search/cdn/simage/shopping/v2/common/nav/ico_gnb_shw.png) no-repeat;
   background-size: 130px 90px;
   font-size: 0;
   position: absolute;
   top: 13px;
   width: 28px;
-  height: 28px;
-}
+  height: 28px; }
 
 .icon_slide {
   display: inline-block;
@@ -25,25 +21,21 @@
   height: 25px;
   font-size: 0;
   line-height: 0;
-  background: url(//shop1.daumcdn.net/search/cdn/simage/shopping/v2/common/img_home_150131.png)
-    no-repeat;
-  text-indent: -9999px;
-}
+  background: url(//shop1.daumcdn.net/search/cdn/simage/shopping/v2/common/img_home_150131.png) no-repeat;
+  text-indent: -9999px; }
 
 .bar {
   float: left;
   width: 1px;
   height: 18px;
   margin-top: 18px;
-  background-color: #e3e3e3;
-}
+  background-color: #e3e3e3; }
 
 .shoppinglists {
   float: left;
   overflow: hidden;
   width: 972px;
-  background-color: #fff;
-}
+  background-color: #fff; }
 
 .shoppinglist {
   float: left;
@@ -52,55 +44,48 @@
   padding: 21px;
   border-bottom: 0 none;
   border-top: 1px solid rgba(0, 0, 0, 0.05);
-  border-right: 1px solid rgba(0, 0, 0, 0.05);
-}
-.shoppinglist img {
-  width: 200px;
-  aspect-ratio: auto 200 / 200;
-  height: 200px;
-}
-.shoppinglist strong {
-  display: block;
-  overflow: hidden;
-  margin: 10px 1px;
-  font-size: 14px;
-  white-space: nowrap;
-}
-.shoppinglist span {
-  display: block;
-  color: #888;
-  font-size: 12px;
-}
+  border-right: 1px solid rgba(0, 0, 0, 0.05); }
+  .shoppinglist img {
+    width: 200px;
+    aspect-ratio: auto 200 / 200;
+    height: 200px; }
+  .shoppinglist strong {
+    display: block;
+    overflow: hidden;
+    margin: 10px 1px;
+    font-size: 14px;
+    white-space: nowrap; }
+  .shoppinglist span {
+    display: block;
+    color: #888;
+    font-size: 12px; }
 
 header {
   width: 100%;
   padding-top: 43px;
-  font-family: Apple SD Gothic Neo, Malgun Gothic, 맑은 고딕, Dotum, 돋움,
-    sans-serif;
+  font-family: Apple SD Gothic Neo,Malgun Gothic,맑은 고딕,Dotum,돋움,sans-serif;
   background-color: #fff;
   text-align: center;
-  min-width: 1200px;
-}
+  min-width: 1200px; }
 
 .header__searchbar {
   display: inline-block;
-  vertical-align: top;
-}
-.header__searchbar img {
-  width: 119px;
-  height: auto;
-}
-.header__searchbar input {
-  float: right;
-  margin: 0 24px 0 30px;
-  width: 670px;
-  height: 54px;
-  padding: 16px 60px 14px 30px;
-  border: 1px solid #cecfd1;
-  border-radius: 10px;
-  background-color: #fff;
-  box-sizing: border-box;
-}
+  vertical-align: top; }
+  .header__searchbar img {
+    width: 119px;
+    height: auto; }
+  .header__searchbar div {
+    float: right; }
+    .header__searchbar div input {
+      float: right;
+      margin: 0 24px 0 30px;
+      width: 670px;
+      height: 54px;
+      padding: 16px 60px 14px 30px;
+      border: 1px solid #cecfd1;
+      border-radius: 10px;
+      background-color: #fff;
+      box-sizing: border-box; }
 
 .header__navbar {
   box-sizing: border-box;
@@ -113,78 +98,80 @@ header {
   padding-left: 30px;
   padding-right: 30px;
   margin-top: 40px;
-  box-shadow: 0 1px rgba(0, 0, 0, 0.16);
-}
-.header__navbar div {
-  float: left;
-}
-.header__navbar ul li {
-  float: left;
-  color: #222;
-}
+  box-shadow: 0 1px rgba(0, 0, 0, 0.16); }
+  .header__navbar div {
+    float: left; }
+  .header__navbar ul li {
+    float: left;
+    color: #222; }
 
 .header__navbar__hashtag {
-  float: left;
-}
-.header__navbar__hashtag li {
-  padding: 0 6px;
-  opacity: 50%;
-}
+  float: left; }
+  .header__navbar__hashtag li {
+    padding: 0 6px;
+    opacity: 50%; }
 
 .header__navbar__hotDeal {
-  float: left;
-}
-.header__navbar__hotDeal li {
-  font-weight: 700;
-  font-size: 16px;
-  padding: 0 13px;
-  letter-spacing: -0.08em;
-}
+  float: left; }
+  .header__navbar__hotDeal li {
+    font-weight: 700;
+    font-size: 16px;
+    padding: 0 13px;
+    letter-spacing: -.08em; }
 
 .header__navbar__login {
   float: right;
   position: relative;
-  text-align: left;
-}
-.header__navbar__login .ico_user {
-  left: 0;
-  background-position: -30px -30px;
-}
+  text-align: left; }
+  .header__navbar__login .ico_user {
+    left: 0;
+    background-position: -30px -30px; }
 
 .navber__login__login {
   width: 70px;
-  padding-left: 33px;
-}
+  padding-left: 33px; }
 
 .navber__login__lastItem {
   width: 90px;
   padding: 0 16px 0 34px;
   position: relative;
-  text-align: left;
-}
-.navber__login__lastItem .ico_products {
-  left: 0;
-  background-position: -60px -30px;
-}
-.navber__login__lastItem .ico_arrow {
-  right: 6px;
-  top: 26px;
-  width: 8px;
-  height: 5px;
-  background-position: -60px -70px;
-}
+  text-align: left; }
+  .navber__login__lastItem .ico_products {
+    left: 0;
+    background-position: -60px -30px; }
+  .navber__login__lastItem .ico_arrow {
+    right: 6px;
+    top: 26px;
+    width: 8px;
+    height: 5px;
+    background-position: -60px -70px; }
 
 .header__navbar__catagory {
   position: relative;
   text-align: left;
   width: 82px;
   height: 54px;
-  padding-left: 40px;
-}
-.header__navbar__catagory .ico_menu {
-  left: 4px;
-  background-position: 0 -30px;
-}
+  padding-left: 40px; }
+  .header__navbar__catagory .ico_menu {
+    left: 4px;
+    background-position: 0 -30px; }
+
+.header__keywords {
+  position: absolute;
+  top: 47px;
+  position: absolute;
+  left: 328px; }
+  .header__keywords li {
+    overflow: hidden;
+    height: 22px;
+    font-weight: 700;
+    font-size: 20px;
+    line-height: 22px;
+    color: #939393;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
+    margin: 15px; }
 
 .main__banner {
   overflow: hidden;
@@ -193,42 +180,35 @@ header {
   margin: 0 auto;
   border: 1px solid #e4e4e4;
   border-bottom: 0 none;
-  background-color: #fff;
-}
+  background-color: #fff; }
 
 .main__banner__top {
-  float: top;
-}
-.main__banner__top .banner__left {
-  float: left;
-  position: relative;
-  width: 485px;
-  height: 340px;
-  border-right: 1px solid #f1f1f1;
-  background-color: #fff;
-}
-.main__banner__top .banner__left img {
-  width: 485px;
-  aspect-ratio: auto 485 / 340;
-  height: 340px;
-}
-.main__banner__top .banner__right {
-  position: relative;
-  float: right;
-  width: 485px;
-  height: 340px;
-}
-.main__banner__top .banner__right .banner__slider {
-  display: flex;
-  position: relative;
-  top: 0px;
-  left: -484px;
-  width: 1452px;
-}
-.main__banner__top .banner__right .banner__slider .panel {
-  height: 100%;
-  width: 484px;
-}
+  float: top; }
+  .main__banner__top .banner__left {
+    float: left;
+    position: relative;
+    width: 485px;
+    height: 340px;
+    border-right: 1px solid #f1f1f1;
+    background-color: #fff; }
+    .main__banner__top .banner__left img {
+      width: 485px;
+      aspect-ratio: auto 485 / 340;
+      height: 340px; }
+  .main__banner__top .banner__right {
+    position: relative;
+    float: right;
+    width: 485px;
+    height: 340px; }
+    .main__banner__top .banner__right .banner__slider {
+      display: flex;
+      position: relative;
+      top: 0px;
+      left: -484px;
+      width: 1452px; }
+      .main__banner__top .banner__right .banner__slider .panel {
+        height: 100%;
+        width: 484px; }
 
 .banner__right__btns {
   position: absolute;
@@ -236,62 +216,50 @@ header {
   left: 0;
   width: 100%;
   text-align: center;
-  clear: both;
-}
+  clear: both; }
 
 .prev {
   position: absolute;
   top: -4px;
   left: 160px;
-  background-position: -128px -335px;
-}
+  background-position: -128px -335px; }
 
 .next {
   right: 160px;
   background-position: -145px -335px;
   position: absolute;
-  top: -4px;
-}
+  top: -4px; }
 
 .inner_paging {
-  display: inline-block;
-}
-.inner_paging span {
-  margin-left: 3px;
-  float: left;
-  padding: 5px 0;
-}
-.inner_paging span .num_page {
-  width: 15px;
-  height: 5px;
-  font-size: 0;
-  line-height: 0;
-}
-.inner_paging span .unselected {
-  background-color: #ccc;
-}
-.inner_paging span .selected {
-  background-color: #000;
-}
+  display: inline-block; }
+  .inner_paging span {
+    margin-left: 3px;
+    float: left;
+    padding: 5px 0; }
+    .inner_paging span .num_page {
+      width: 15px;
+      height: 5px;
+      font-size: 0;
+      line-height: 0; }
+    .inner_paging span .unselected {
+      background-color: #ccc; }
+    .inner_paging span .selected {
+      background-color: #000; }
 
 .transitiondefault {
   transition-duration: 300ms;
-  transform: translate3d(0px, 0px, 0px);
-}
+  transform: translate3d(0px, 0px, 0px); }
 
 .more_contents {
   background-color: #ccc;
   height: 54px;
-  width: 971px;
-}
+  width: 971px; }
 
 body {
   height: 500vh;
   background-color: #f3f3f3;
-  font-family: 돋움, dotum, sans-serif;
-}
+  font-family: 돋움,dotum,sans-serif; }
 
 section {
   width: 100%;
-  padding-top: 19px;
-}
+  padding-top: 19px; }

--- a/shopping/public/stylesheets/style.css
+++ b/shopping/public/stylesheets/style.css
@@ -223,6 +223,18 @@ header {
   font-weight: 700;
   font-family: robotoitalic,Apple SD Gothic Neo,Malgun Gothic,맑은 고딕,Dotum,돋움,sans-serif; }
 
+.itemList {
+  display: block;
+  overflow: hidden;
+  height: 26px;
+  padding: 0 29px;
+  line-height: 26px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+  letter-spacing: -.05em;
+  color: #222; }
+
 .main__banner {
   overflow: hidden;
   position: relative;

--- a/shopping/public/stylesheets/style.css
+++ b/shopping/public/stylesheets/style.css
@@ -70,7 +70,9 @@ header {
 
 .header__searchbar {
   display: inline-block;
-  vertical-align: top; }
+  vertical-align: top;
+  overflow-y: hidden;
+  position: relative; }
   .header__searchbar img {
     width: 119px;
     height: auto; }
@@ -157,10 +159,9 @@ header {
     background-position: 0 -30px; }
 
 .header__keywords {
+  top: 4px;
   position: absolute;
-  top: 47px;
-  position: absolute;
-  left: 328px; }
+  left: 155px; }
   .header__keywords li {
     overflow: hidden;
     height: 22px;

--- a/shopping/public/stylesheets/style.css
+++ b/shopping/public/stylesheets/style.css
@@ -60,6 +60,9 @@
     color: #888;
     font-size: 12px; }
 
+.none {
+  visibility: hidden; }
+
 header {
   width: 100%;
   padding-top: 43px;
@@ -81,13 +84,19 @@ header {
     .header__searchbar div input {
       float: right;
       margin: 0 24px 0 30px;
+      position: relative;
+      z-index: 3;
       width: 670px;
       height: 54px;
       padding: 16px 60px 16px 30px;
       border: 1px solid #cecfd1;
       border-radius: 10px;
-      background-color: #fff;
+      background-color: transparent;
       box-sizing: border-box; }
+      .header__searchbar div input:focus {
+        outline: none;
+        border: 1px solid #f95139;
+        border-radius: 10px; }
 
 .header__navbar {
   box-sizing: border-box;
@@ -163,7 +172,8 @@ header {
   transform: translateY(0px);
   top: 0px;
   position: absolute;
-  left: 155px; }
+  left: 155px;
+  z-index: 2; }
   .header__keywords li {
     overflow: hidden;
     height: 22px;
@@ -180,7 +190,7 @@ header {
   position: absolute;
   padding: 25px 29px 23px;
   overflow: hidden;
-  left: 327px;
+  left: 364px;
   top: 109px;
   z-index: 10;
   width: 670px;

--- a/shopping/public/stylesheets/style.css
+++ b/shopping/public/stylesheets/style.css
@@ -188,10 +188,9 @@ header {
 
 .header__suggestion {
   position: absolute;
-  padding: 25px 29px 23px;
   overflow: hidden;
-  left: 364px;
-  top: 109px;
+  left: 360px;
+  top: 97px;
   z-index: 10;
   width: 670px;
   border: 1px solid #f95139;
@@ -199,23 +198,25 @@ header {
   background-color: #fff;
   box-sizing: border-box;
   text-align: left; }
-  .header__suggestion strong {
-    display: block;
-    padding-bottom: 5px;
-    font-size: 16px;
-    color: #a6a6a6;
-    letter-spacing: -.04em; }
-  .header__suggestion ol {
-    display: grid;
-    grid-template-columns: 1fr 1fr; }
-    .header__suggestion ol li {
-      font-size: 14px;
-      letter-spacing: -.05em;
-      color: #222;
-      height: 21px;
-      padding: 12px 15px 0 0;
-      text-overflow: ellipsis;
-      white-space: nowrap; }
+  .header__suggestion div {
+    padding: 25px 29px 23px; }
+    .header__suggestion div strong {
+      display: block;
+      padding-bottom: 5px;
+      font-size: 16px;
+      color: #a6a6a6;
+      letter-spacing: -.04em; }
+    .header__suggestion div ol {
+      display: grid;
+      grid-template-columns: 1fr 1fr; }
+      .header__suggestion div ol li {
+        font-size: 14px;
+        letter-spacing: -.05em;
+        color: #222;
+        height: 21px;
+        padding: 12px 15px 0 0;
+        text-overflow: ellipsis;
+        white-space: nowrap; }
 
 .num {
   margin-right: 10px;

--- a/shopping/public/stylesheets/style.css
+++ b/shopping/public/stylesheets/style.css
@@ -176,6 +176,42 @@ header {
     text-align: left;
     margin: 16px; }
 
+.header__suggestion {
+  position: absolute;
+  padding: 25px 29px 23px;
+  overflow: hidden;
+  left: 327px;
+  top: 109px;
+  z-index: 10;
+  width: 670px;
+  border: 1px solid #f95139;
+  border-radius: 10px;
+  background-color: #fff;
+  box-sizing: border-box;
+  text-align: left; }
+  .header__suggestion strong {
+    display: block;
+    padding-bottom: 5px;
+    font-size: 16px;
+    color: #a6a6a6;
+    letter-spacing: -.04em; }
+  .header__suggestion ol {
+    display: grid;
+    grid-template-columns: 1fr 1fr; }
+    .header__suggestion ol li {
+      font-size: 14px;
+      letter-spacing: -.05em;
+      color: #222;
+      height: 21px;
+      padding: 12px 15px 0 0;
+      text-overflow: ellipsis;
+      white-space: nowrap; }
+
+.num {
+  margin-right: 10px;
+  font-weight: 700;
+  font-family: robotoitalic,Apple SD Gothic Neo,Malgun Gothic,맑은 고딕,Dotum,돋움,sans-serif; }
+
 .main__banner {
   overflow: hidden;
   position: relative;

--- a/shopping/views/index.ejs
+++ b/shopping/views/index.ejs
@@ -15,7 +15,10 @@
     <div class="header__searchbar">
       <img class="header__searchbar__img"
         src="https://search1.daumcdn.net/search/cdn/simage/shopping/v2/common/nav/logo_shw.png">
-      <input type="text">
+      <div>
+        <div class="header__keywords"></div>
+        <input type="text">
+      </div>
     </div>
     <div class="header__keywords"></div>
     <div class="header__navbar">
@@ -84,7 +87,7 @@
               <span>
                 <div class="num_page unselected">2</div>
               </span>
-          
+
             </span>
             <button class="icon_slide next"></button>
           </div>
@@ -127,8 +130,8 @@
             <%= event.mallEventList[3].text2 %>
           </span>
         </li>
-      </ul> 
-      <button class = "more_contents">더보기</button>
+      </ul>
+      <button class="more_contents">더보기</button>
     </div>
   </section>
   <section class="hotDeal_section"></section>

--- a/shopping/views/index.ejs
+++ b/shopping/views/index.ejs
@@ -59,8 +59,8 @@
       </ul>
     </div>
     <div class="header__suggestion none">
-      <strong class="tit__suggestion">인기 쇼핑 키워드</strong>
-      <ol class="suggestion__items"></ol>
+      <div class="suggestionKeywords">
+    </div>
     </div>
 
   </header>

--- a/shopping/views/index.ejs
+++ b/shopping/views/index.ejs
@@ -13,10 +13,12 @@
 <body>
   <header>
     <div class="header__searchbar">
+
+      <div class="header__keywords"></div>
+
       <img class="header__searchbar__img"
         src="https://search1.daumcdn.net/search/cdn/simage/shopping/v2/common/nav/logo_shw.png">
       <div>
-        <div class="header__keywords"></div>
         <input type="text">
       </div>
     </div>
@@ -57,6 +59,7 @@
       </ul>
     </div>
   </header>
+
   <section class="main_section">
     <div class="main__banner layer1">
       <div class="main__banner__top layer1">

--- a/shopping/views/index.ejs
+++ b/shopping/views/index.ejs
@@ -58,7 +58,7 @@
 
       </ul>
     </div>
-    <div class="header__suggestion">
+    <div class="header__suggestion none">
       <strong class="tit__suggestion">인기 쇼핑 키워드</strong>
       <ol class="suggestion__items"></ol>
     </div>

--- a/shopping/views/index.ejs
+++ b/shopping/views/index.ejs
@@ -15,7 +15,7 @@
     <div class="header__searchbar">
 
       <div class="header__keywords"></div>
-
+     
       <img class="header__searchbar__img"
         src="https://search1.daumcdn.net/search/cdn/simage/shopping/v2/common/nav/logo_shw.png">
       <div>
@@ -58,6 +58,11 @@
 
       </ul>
     </div>
+    <div class="header__suggestion">
+      <strong class="tit__suggestion">인기 쇼핑 키워드</strong>
+      <ol class="suggestion__items"></ol>
+    </div>
+
   </header>
 
   <section class="main_section">


### PR DESCRIPTION
## 구현 상황
![screen-recording-_4_](https://user-images.githubusercontent.com/68339352/110668801-09795900-820f-11eb-8c95-138c1b495996.gif)

## Task
### 공통

- [x]  git 에서 이전 설정 가져오기

### front

- [x]  인기 검색어 롤링 노출 (10개)
- [x]  →  shopping how 에서 인기검색어 list fetch 해온다.
- [x]  → `.header__keywords` class 가진 div 안에 `<li>${list}</li>`  를 innerHTML 로 차례대로 넣는다.(forEach)
- [x]  → css 입힌다
- [x]  -> setinterval 함수를 비동기로 만든다
- [x]  → promise  loop

- [x]  focus 후 `인기 쇼핑 키워드` 노출
- [x]  →`인기 쇼핑 키워드` DOC 작성
- [x]  →CSS 입히기
- [x]  →focus event 후에 add class 해서 input border color 를 바꿔준다.
- [x]  →이벤트 델리게이션을 통해서 다른 곳을 클릭했을때 창이 사라지게한다? 혹은 focus on 이벤트→이벤트 델리게이션을 통해서 다른 곳을 클릭했을때 창이 사라지게한다? 혹은 focus on 이벤트
- [x]  input event > 백으로 input.value 넘겨준다.
- [ ]  
- [ ]  `자동완성결과` 에서 일치되는 글자 색 하이라이트
- [ ]  바깥 쪽 "click" 시 `인기 쇼핑 키워드` , `자동완성결과` 닫기
- [ ]  키보드 화살표로 `자동완성 결과` focus 가능 > foucs event 시 input.value 바꿈

### beck

- [x]  [https://www.amazon.com/korea/s?k=korea](https://www.amazon.com/korea/s?k=korea) 아마존에서 fetch 해온다.
- [ ]  동일하게 요청된 데이터는 캐시기능을 활용해서 효과적으로 활용(클라이언트/서버 아무것이나 방법을 찾아서 적용)

## 해결해야할 점
1. input 에 입력한채로 focus를 취소하면 그 위로 롤링리스트가 생겨난다. 
2. 쇼핑하우의 데이터를 가져오다보니  JSONP를 이용하여야 되서 전역함수 선언을 했다.  