### PR TITLE
[Goody] 쇼핑하우 검색창 구현 마무리

### DIFF
--- a/public/css/main.scss
+++ b/public/css/main.scss
@@ -276,3 +276,8 @@ input {
 .hash_link {
     padding: 0 10px;
 }
+
+
+.found {
+    color: orange;
+}

--- a/public/css/main.scss
+++ b/public/css/main.scss
@@ -281,3 +281,7 @@ input {
 .found {
     color: orange;
 }
+
+.selected {
+    background-color: lightgray;
+}

--- a/public/js/popularKeywords.js
+++ b/public/js/popularKeywords.js
@@ -51,6 +51,7 @@ PopularKeywords.prototype.makeRankList = function () {
 }
 
 PopularKeywords.prototype.activateSearch = function () {
+    
     this.hide(this.wrapRoll);
     this.show(this.searchInput);
     this.show(this.popularSearch);
@@ -64,6 +65,7 @@ PopularKeywords.prototype.deActivateSearch = function () {
     this.hide(this.searchInput);
     this.show(this.wrapRoll);
     this.hide(this.relContainer);
+    this.searchInput.blur();
     this.searchBox.style.border = `#ececec solid 1px`;
 }
 

--- a/public/js/popularKeywords.js
+++ b/public/js/popularKeywords.js
@@ -52,10 +52,11 @@ PopularKeywords.prototype.makeRankList = function () {
 
 PopularKeywords.prototype.activateSearch = function () {
     
+
     this.hide(this.wrapRoll);
     this.show(this.searchInput);
     this.show(this.popularSearch);
-    this.show(this.relContainer);
+    this.hide(this.relContainer);
     this.searchInput.focus();
     this.searchBox.style.border = `red solid 1px`;
 }

--- a/public/js/relatedKeywords.js
+++ b/public/js/relatedKeywords.js
@@ -6,9 +6,8 @@ function RelatedKeywords() {
     this.wrapRoll = document.querySelector(".wrap_roll_keywords");
     this.cache = '';
     this.listIdx = 0;
-    this.time;
+    this.timeout;
     this.onEvent();
-    this.checkInput();
 }
 
 
@@ -20,6 +19,13 @@ RelatedKeywords.prototype.onEvent = function () {
             this.bindedPrintKey(e);
         }
     });
+    this.searchInput.addEventListener("input", (e) => {
+        if(this.timeout) clearTimeout(this.timeout);
+        this.timeout = setTimeout(() => {
+            this.loadData(this.searchInput.value);
+            this.showHide();
+        },500);
+    })
 }
 
 RelatedKeywords.prototype.printKey = function (e) {
@@ -44,7 +50,6 @@ RelatedKeywords.prototype.printKey = function (e) {
         this.ul.childNodes[this.listIdx].classList.remove("selected");
         this.listIdx--;
     }
-    // clearTimeout(this.time);
 }
 
 
@@ -108,29 +113,6 @@ RelatedKeywords.prototype.fillSearch = function (suggestArr) {
 }
 
 
-RelatedKeywords.prototype.checkInput = function () {
-    const beforeInput = this.searchInput.value;
-    this.runSearch(beforeInput)
-    .then(res => {
-        if(this.searchInput.value === res) {
-            console.log("입력멈춤");
-            this.loadData(this.searchInput.value);
-        } else {
-            console.log("입력변함 혹은 입력비어있음");
-        }
-    })
-    .then(() => this.checkInput())
-    .then(this.showHide());
-}
-
-
-RelatedKeywords.prototype.runSearch = function (beforeInput) {
-    return new Promise((resolve, reject) => {
-        setTimeout(() => {
-            resolve(beforeInput);
-        }, 1000);
-    });
-}
 
 
 

--- a/public/js/relatedKeywords.js
+++ b/public/js/relatedKeywords.js
@@ -15,9 +15,10 @@ function RelatedKeywords() {
 
 RelatedKeywords.prototype.onEvent = function () {
     this.searchInput.addEventListener("keydown", (e) => {
-
-        this.bindedPrintKey = this.printKey.bind(this)
-        this.bindedPrintKey(e);
+        if(e.key === "ArrowDown" || e.key === "ArrowUp") {
+            this.bindedPrintKey = this.printKey.bind(this)
+            this.bindedPrintKey(e);
+        }
     });
 }
 
@@ -27,7 +28,6 @@ RelatedKeywords.prototype.printKey = function (e) {
     // if (this.listIdx < 0) this.listIdx = 1;
 
     if (e.key === "ArrowDown") {
-        clearTimeout(this.time);
         this.searchInput.value = (this.ul.childNodes[this.listIdx].textContent);
 
         if (this.listIdx === 0) {
@@ -37,35 +37,16 @@ RelatedKeywords.prototype.printKey = function (e) {
             this.ul.childNodes[this.listIdx].classList.add("selected");
         }
         this.listIdx++;
-    } else if (e.key === "ArrowUp") {
-        clearTimeout(this.time);
+    } 
+    if (e.key === "ArrowUp") {
         this.searchInput.value = (this.ul.childNodes[this.listIdx - 1].textContent);
         this.ul.childNodes[this.listIdx - 1].classList.add("selected");
         this.ul.childNodes[this.listIdx].classList.remove("selected");
         this.listIdx--;
-    } 
+    }
+    // clearTimeout(this.time);
 }
 
-RelatedKeywords.prototype.checkInput = function () {
-    const beforeInput = this.searchInput.value;
-    this.timer(beforeInput);
-}
-
-
-RelatedKeywords.prototype.timer = function (beforeInput) {
-    this.time = setTimeout(() => {
-        if (this.searchInput.value === beforeInput) {
-            console.log("입력멈춤");
-            this.loadData(this.searchInput.value);
-
-        } else {
-            console.log("입력변함 혹은 입력비어있음");
-
-        }
-        this.checkInput();
-        this.showHide();
-    }, 1000);
-}
 
 RelatedKeywords.prototype.showHide = function () {
     if (this.searchInput.value === "" || this.searchInput !== document.activeElement) {
@@ -125,5 +106,33 @@ RelatedKeywords.prototype.fillSearch = function (suggestArr) {
     })
 
 }
+
+
+RelatedKeywords.prototype.checkInput = function () {
+    const beforeInput = this.searchInput.value;
+    this.runSearch(beforeInput)
+    .then(res => {
+        if(this.searchInput.value === res) {
+            console.log("입력멈춤");
+            this.loadData(this.searchInput.value);
+        } else {
+            console.log("입력변함 혹은 입력비어있음");
+        }
+    })
+    .then(() => this.checkInput())
+    .then(this.showHide());
+}
+
+
+RelatedKeywords.prototype.runSearch = function (beforeInput) {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => {
+            resolve(beforeInput);
+        }, 1000);
+    });
+}
+
+
+
 
 export { RelatedKeywords };

--- a/public/js/relatedKeywords.js
+++ b/public/js/relatedKeywords.js
@@ -3,6 +3,7 @@ function RelatedKeywords() {
     this.searchInput = document.querySelector(".search_input");
     this.relContainer = document.querySelector(".rel_search");
     this.popularSearch = document.querySelector(".popular_search");
+    this.wrapRoll = document.querySelector(".wrap_roll_keywords");
     this.cache = '';
     this.checkInput();
 }
@@ -15,7 +16,7 @@ RelatedKeywords.prototype.checkInput = function () {
 
 RelatedKeywords.prototype.timer = function (beforeInput) {
     setTimeout(() => {
-        if (this.searchInput.value === beforeInput && this.searchInput.value !== "") {
+        if (this.searchInput.value === beforeInput) {
             console.log("입력멈춤");
             this.loadData(this.searchInput.value);
             this.checkInput();
@@ -25,17 +26,21 @@ RelatedKeywords.prototype.timer = function (beforeInput) {
             this.checkInput();
         }
 
-        if (this.searchInput.value === "") {
-            this.relContainer.classList.add("hide");
-
-        } else {
-            this.relContainer.classList.remove("hide");
-        }
-
+        this.showHide();
     }, 500);
 }
 
+RelatedKeywords.prototype.showHide = function() {
+    if (this.searchInput.value === "" || this.searchInput !== document.activeElement) {
+        this.relContainer.classList.add("hide");
+        this.popularSearch.classList.remove("hide");
+        if(!this.wrapRoll.classList.contains("hide")) this.popularSearch.classList.add("hide");
 
+    } else {
+        this.popularSearch.classList.add("hide");
+        this.relContainer.classList.remove("hide");
+    }
+}
 
 
 RelatedKeywords.prototype.loadData = function (input) {

--- a/public/js/relatedKeywords.js
+++ b/public/js/relatedKeywords.js
@@ -57,10 +57,30 @@ RelatedKeywords.prototype.loadData = function (input) {
 
 
 RelatedKeywords.prototype.fillSearch = function (suggestArr) {
+
     this.ul.innerHTML = "";
+    let pattern = this.searchInput.value;
+    let re = new RegExp(pattern, "g");
+
     suggestArr.forEach((el) => {
         const li = document.createElement("li");
-        li.innerHTML = el.value;
+
+        let searchString = el.value;
+        let matchArray;
+        let resultString= "<pre>";
+        let first = 0;
+        let last = 0;
+    
+        while ((matchArray = re.exec(searchString)) != null ) {
+            last = matchArray.index;
+            resultString += searchString.substring(first, last);
+            resultString += "<span class='found'>" + matchArray[0] + "</span>";
+            first = re.lastIndex; 
+        }
+        resultString += searchString.substring(first, searchString.length);
+        resultString += "</pre>";
+
+        li.innerHTML = resultString;
         this.ul.appendChild(li);
     })
 }

--- a/public/js/relatedKeywords.js
+++ b/public/js/relatedKeywords.js
@@ -6,9 +6,12 @@ function RelatedKeywords() {
     this.wrapRoll = document.querySelector(".wrap_roll_keywords");
     this.cache = '';
     this.listIdx = 0;
+    this.time;
     this.onEvent();
     this.checkInput();
 }
+
+
 
 RelatedKeywords.prototype.onEvent = function () {
     this.searchInput.addEventListener("keydown", (e) => {
@@ -20,10 +23,11 @@ RelatedKeywords.prototype.onEvent = function () {
 
 RelatedKeywords.prototype.printKey = function (e) {
 
-
-    if(this.listIdx > 10) this.listIdx = 10;
+    if (this.listIdx > 10) this.listIdx = 10;
+    // if (this.listIdx < 0) this.listIdx = 1;
 
     if (e.key === "ArrowDown") {
+        clearTimeout(this.time);
         this.searchInput.value = (this.ul.childNodes[this.listIdx].textContent);
 
         if (this.listIdx === 0) {
@@ -33,15 +37,13 @@ RelatedKeywords.prototype.printKey = function (e) {
             this.ul.childNodes[this.listIdx].classList.add("selected");
         }
         this.listIdx++;
-    }
-
-    if (e.key === "ArrowUp") {
-        this.searchInput.value = (this.ul.childNodes[this.listIdx].textContent);
-        this.ul.childNodes[this.listIdx].classList.remove("selected");
+    } else if (e.key === "ArrowUp") {
+        clearTimeout(this.time);
+        this.searchInput.value = (this.ul.childNodes[this.listIdx - 1].textContent);
         this.ul.childNodes[this.listIdx - 1].classList.add("selected");
-
+        this.ul.childNodes[this.listIdx].classList.remove("selected");
         this.listIdx--;
-    }
+    } 
 }
 
 RelatedKeywords.prototype.checkInput = function () {
@@ -51,18 +53,18 @@ RelatedKeywords.prototype.checkInput = function () {
 
 
 RelatedKeywords.prototype.timer = function (beforeInput) {
-    setTimeout(() => {
+    this.time = setTimeout(() => {
         if (this.searchInput.value === beforeInput) {
             console.log("입력멈춤");
             this.loadData(this.searchInput.value);
 
         } else {
             console.log("입력변함 혹은 입력비어있음");
-        
+
         }
         this.checkInput();
         this.showHide();
-    }, 500);
+    }, 1000);
 }
 
 RelatedKeywords.prototype.showHide = function () {
@@ -83,18 +85,18 @@ RelatedKeywords.prototype.loadData = function (input) {
     const url = `https://completion.amazon.com/api/2017/suggestions?session-id=135-3077052-6015425&customer-id=&request-id=DMRETXPQ3PZJQ5TKYSWX&page-type=Gateway&lop=en_US&site-variant=desktop&client-info=amazon-search-ui&mid=ATVPDKIKX0DER&alias=aps&b2b=0&fresh=0&ks=undefined&prefix=${input}&event=onFocusWithSearchTerm&limit=11&fb=1&suggestion-type=KEYWORD&suggestion-type=WIDGET&_=1615280967091`;
 
     if (this.cache === url) return;
-    
+
     if (this.cache !== url) {
-        this.cache = url;
         fetch(url)
             .then((res) => res.json())
-            .then((res) => this.fillSearch(res.suggestions));
+            .then((res) => this.fillSearch(res.suggestions))
+            .then(this.cache = url);
     }
 }
 
 
 RelatedKeywords.prototype.fillSearch = function (suggestArr) {
-   
+
     this.ul.innerHTML = "";
     this.listIdx = 0;
     const pattern = this.searchInput.value;

--- a/public/js/relatedKeywords.js
+++ b/public/js/relatedKeywords.js
@@ -5,7 +5,43 @@ function RelatedKeywords() {
     this.popularSearch = document.querySelector(".popular_search");
     this.wrapRoll = document.querySelector(".wrap_roll_keywords");
     this.cache = '';
+    this.listIdx = 0;
+    this.onEvent();
     this.checkInput();
+}
+
+RelatedKeywords.prototype.onEvent = function () {
+    this.searchInput.addEventListener("keydown", (e) => {
+
+        this.bindedPrintKey = this.printKey.bind(this)
+        this.bindedPrintKey(e);
+    });
+}
+
+RelatedKeywords.prototype.printKey = function (e) {
+
+
+    if(this.listIdx > 10) this.listIdx = 10;
+
+    if (e.key === "ArrowDown") {
+        this.searchInput.value = (this.ul.childNodes[this.listIdx].textContent);
+
+        if (this.listIdx === 0) {
+            this.ul.childNodes[this.listIdx].classList.add("selected");
+        } else {
+            this.ul.childNodes[this.listIdx - 1].classList.remove("selected");
+            this.ul.childNodes[this.listIdx].classList.add("selected");
+        }
+        this.listIdx++;
+    }
+
+    if (e.key === "ArrowUp") {
+        this.searchInput.value = (this.ul.childNodes[this.listIdx].textContent);
+        this.ul.childNodes[this.listIdx].classList.remove("selected");
+        this.ul.childNodes[this.listIdx - 1].classList.add("selected");
+
+        this.listIdx--;
+    }
 }
 
 RelatedKeywords.prototype.checkInput = function () {
@@ -19,22 +55,22 @@ RelatedKeywords.prototype.timer = function (beforeInput) {
         if (this.searchInput.value === beforeInput) {
             console.log("입력멈춤");
             this.loadData(this.searchInput.value);
-            this.checkInput();
 
         } else {
             console.log("입력변함 혹은 입력비어있음");
-            this.checkInput();
+        
         }
-
+        this.checkInput();
         this.showHide();
     }, 500);
 }
 
-RelatedKeywords.prototype.showHide = function() {
+RelatedKeywords.prototype.showHide = function () {
     if (this.searchInput.value === "" || this.searchInput !== document.activeElement) {
+        this.listIdx = 0;
         this.relContainer.classList.add("hide");
         this.popularSearch.classList.remove("hide");
-        if(!this.wrapRoll.classList.contains("hide")) this.popularSearch.classList.add("hide");
+        if (!this.wrapRoll.classList.contains("hide")) this.popularSearch.classList.add("hide");
 
     } else {
         this.popularSearch.classList.add("hide");
@@ -47,7 +83,8 @@ RelatedKeywords.prototype.loadData = function (input) {
     const url = `https://completion.amazon.com/api/2017/suggestions?session-id=135-3077052-6015425&customer-id=&request-id=DMRETXPQ3PZJQ5TKYSWX&page-type=Gateway&lop=en_US&site-variant=desktop&client-info=amazon-search-ui&mid=ATVPDKIKX0DER&alias=aps&b2b=0&fresh=0&ks=undefined&prefix=${input}&event=onFocusWithSearchTerm&limit=11&fb=1&suggestion-type=KEYWORD&suggestion-type=WIDGET&_=1615280967091`;
 
     if (this.cache === url) return;
-    else {
+    
+    if (this.cache !== url) {
         this.cache = url;
         fetch(url)
             .then((res) => res.json())
@@ -57,25 +94,26 @@ RelatedKeywords.prototype.loadData = function (input) {
 
 
 RelatedKeywords.prototype.fillSearch = function (suggestArr) {
-
+   
     this.ul.innerHTML = "";
-    let pattern = this.searchInput.value;
-    let re = new RegExp(pattern, "g");
+    this.listIdx = 0;
+    const pattern = this.searchInput.value;
+    const re = new RegExp(pattern, "g");
 
     suggestArr.forEach((el) => {
         const li = document.createElement("li");
 
         let searchString = el.value;
         let matchArray;
-        let resultString= "<pre>";
+        let resultString = "<pre>";
         let first = 0;
         let last = 0;
-    
-        while ((matchArray = re.exec(searchString)) != null ) {
+
+        while ((matchArray = re.exec(searchString)) != null) {
             last = matchArray.index;
             resultString += searchString.substring(first, last);
             resultString += "<span class='found'>" + matchArray[0] + "</span>";
-            first = re.lastIndex; 
+            first = re.lastIndex;
         }
         resultString += searchString.substring(first, searchString.length);
         resultString += "</pre>";
@@ -83,6 +121,7 @@ RelatedKeywords.prototype.fillSearch = function (suggestArr) {
         li.innerHTML = resultString;
         this.ul.appendChild(li);
     })
+
 }
 
 export { RelatedKeywords };

--- a/public/js/relatedKeywords.js
+++ b/public/js/relatedKeywords.js
@@ -14,25 +14,29 @@ function RelatedKeywords() {
 
 RelatedKeywords.prototype.onEvent = function () {
     this.searchInput.addEventListener("keydown", (e) => {
-        if(e.key === "ArrowDown" || e.key === "ArrowUp") {
-            this.bindedPrintKey = this.printKey.bind(this)
-            this.bindedPrintKey(e);
-        }
+        this.bindedPrintKey = this.printKey.bind(this)
+        this.bindedPrintKey(e);
     });
     this.searchInput.addEventListener("input", (e) => {
-        if(this.timeout) clearTimeout(this.timeout);
-        this.timeout = setTimeout(() => {
-            this.loadData(this.searchInput.value);
-            this.showHide();
-        },500);
+        if (this.timeout) clearTimeout(this.timeout);
+
+        this.runSearch(this.searchInput.value)
+        .then((input) => this.loadData(input))
+        .then(this.showHide());
     })
 }
 
+
+RelatedKeywords.prototype.runSearch = function (input) {
+    return new Promise((resolve, reject) => {
+        this.timeout = setTimeout(() => {
+            resolve(input);
+        }, 1000);
+    })
+}
+
+
 RelatedKeywords.prototype.printKey = function (e) {
-
-    if (this.listIdx > 10) this.listIdx = 10;
-    // if (this.listIdx < 0) this.listIdx = 1;
-
     if (e.key === "ArrowDown") {
         this.searchInput.value = (this.ul.childNodes[this.listIdx].textContent);
 
@@ -43,12 +47,14 @@ RelatedKeywords.prototype.printKey = function (e) {
             this.ul.childNodes[this.listIdx].classList.add("selected");
         }
         this.listIdx++;
-    } 
+        if (this.listIdx > this.ul.childNodes.length) this.listIdx = this.ul.childNodes.length;
+    }
     if (e.key === "ArrowUp") {
         this.searchInput.value = (this.ul.childNodes[this.listIdx - 1].textContent);
         this.ul.childNodes[this.listIdx - 1].classList.add("selected");
         this.ul.childNodes[this.listIdx].classList.remove("selected");
         this.listIdx--;
+        if (this.listIdx < 0) this.listIdx = 0;
     }
 }
 
@@ -56,6 +62,7 @@ RelatedKeywords.prototype.printKey = function (e) {
 RelatedKeywords.prototype.showHide = function () {
     if (this.searchInput.value === "" || this.searchInput !== document.activeElement) {
         this.listIdx = 0;
+        this.ul.innerHTML = "";
         this.relContainer.classList.add("hide");
         this.popularSearch.classList.remove("hide");
         if (!this.wrapRoll.classList.contains("hide")) this.popularSearch.classList.add("hide");
@@ -111,10 +118,5 @@ RelatedKeywords.prototype.fillSearch = function (suggestArr) {
     })
 
 }
-
-
-
-
-
 
 export { RelatedKeywords };

--- a/views/main.ejs
+++ b/views/main.ejs
@@ -16,7 +16,7 @@
                 <div class="wrap_roll_keywords">
                     <ol class = "list_roll_keywords"></ol>     
                 </div>
-                <div class = "rel_search">
+                <div class = "rel_search hide">
                     <ul class="pop_rel_keywords">
                     </ul>
                 </div>


### PR DESCRIPTION


## feature list

- [x] 기본 세팅
  - [x] express 로 서버 토대 구축
  - [x] 이전 쇼핑하우 코드 가져오기
  - [x] HTML, CSS 미션에 맞게 재구성



<br>



- [x] 인기 검색어 순위 롤링 기능 구현

  - [x] 롤링될 div를 html 내부에 생성

  - [x] 인기 검색어 10개 데이터 div 내부에 작성

  - [x] 롤링 div css 스타일링

  - [x] js 로 롤링 기능 구현



<br>



- [x] 검색창 focus 인기쇼핑키워드 노출 기능 구현
  - [x] 검색창에 focus 이벤트 발생하면 검색창 하단에 인기 쇼핑 키워드 div 의 display : none 삭제

  - [x] 검색어 입력 시작하면 해당 div의 display : none 추가



<br>



- [x] 검색창 자동완성 기능 구현
  - [x] 자동완성될 검색어 키워드 생성 or fetch 로 아마존에서 받아오기
  - [x] 검색창에 글자 입력하면 인기 쇼핑 키워드 div 숨김 
  - [x] 검색창에 글자 입력하면 추천검색어 div 드러냄
  - [x] 추천검색어 div 내부는 검색창에 입력한 글자가 포함된 추천 검색어들로 구성
  - [x] 추천 검색어와 검색창에 입력한 글자 비교하여 일치하는 글자는 하이라이트(정규표현식)
  - [x] 추천검색과 인기쇼핑키워드 div 숨김 및 보임 처리



<br>



- [x] 선택 추천 키워드 입력창에 반영 기능 구현
  - [x] 자동완성된 검색어 키워드 창이 보이는 상태에서 방향키 위/아래 입력받음
  - [x] 위/아래 입력에 따라 검색어 키워드 위에서부터 하나씩 이동하며 선택 
  - [x] 선택된 키워드는 입력창에 value로 반영
  - [x] 위/아래 키보드 입력할 땐 추천검색어가 새로고침 되지 않도록 하기



<br>



- [ ] 리팩토링
  - [x] 추천검색어 데이터로드 쓰로틀링에서 디바운싱으로 바꾸기
  - [x] setTimeout 안에서 모든 비동기 로직을 처리하던걸 Promise로 리팩토링하기
  - [ ] 키보드 위/아래 입력 버그 고치기


## 회고
금요일 수업에 크롱이 setTimeout 으로 구현한 사람들 Promise 로 고치라고 하신 말에 뜨끔했습니다..
덧붙여주신 setTimeout을 Promise로 감싸라는 조언 덕분에 이제 조금은 Promise를 알 것 같기도..?
구현에 급급해서 리팩토링을 많이 못했는데, 구현하는 과정에서
디바운싱, 스로틀링, 비동기 로직 이해, 프로토타입, CSS 스타일 선택 등 배운 건  많아서 후회는 없네요.
키보드 위/아래 입력에 버그가 하나 남았는데.. 시간 내에 못 고친건 쪼끔 아쉽네요.
토요일 낮까지만 좀 더 고쳐보고, 안되면 
주말동안은 알고리즘 공부랑 다음 프로젝트 기획을 해야할 것 같습니다.
이번주도 다들 고생 많으셨습니다.
크롱 짱! 프론트 짱!