### PR TITLE
[Rano] Search UI step4

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -360,7 +360,7 @@ a {
   padding: 2px 22px;
   position: relative;
 }
-.header__logo-search .search__bar input {
+.header__logo-search .search__bar .search__input {
   color: #333;
   display: block;
   width: 95%;

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -4,7 +4,7 @@
   background-size: 130px 90px;
   display: block;
 }
-.icon__carousel, .i-slide__paging--next, .i-slide__paging--prev {
+.icon__carousel, .i-remove, .i-slide__paging--next, .i-slide__paging--prev {
   background: url("/img/img_home.png") no-repeat;
   display: block;
 }
@@ -17,6 +17,10 @@
   display: block;
 }
 
+.wh-8, .i-remove {
+  width: 8px;
+  height: 8px;
+}
 .wh-23, .i-search {
   width: 23px;
   height: 23px;
@@ -72,6 +76,9 @@
 .i-theme {
   background-position: 0 -850px;
   margin: 8px 4px 0 0;
+}
+.i-remove {
+  background-position: -149.5px -57.5px;
 }
 
 body {
@@ -431,10 +438,10 @@ a {
 .header__logo-search .search__suggestion__similarwords li > a:hover, .header__logo-search .search__suggestion__similarwords a.selected {
   background-color: #f0f0f0;
 }
-.header__logo-search .search__suggestion__inner {
+.header__logo-search .search__suggestion__inner, .header__logo-search .search__suggestion__recent {
   font-size: 13px;
 }
-.header__logo-search .search__suggestion__inner p {
+.header__logo-search .search__suggestion__inner p, .header__logo-search .search__suggestion__recent p {
   display: block;
   padding: 6px 0 8px;
   font-size: 16px;
@@ -442,7 +449,7 @@ a {
   color: #a6a6a6;
   letter-spacing: -1.15px;
 }
-.header__logo-search .search__suggestion__inner .inner__list {
+.header__logo-search .search__suggestion__inner .inner__list, .header__logo-search .search__suggestion__inner .recent__list, .header__logo-search .search__suggestion__recent .inner__list, .header__logo-search .search__suggestion__recent .recent__list {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(5, 1fr);
@@ -458,6 +465,11 @@ a {
 .header__logo-search .search__suggestion__inner li > span {
   margin-right: 10px;
   font-weight: 700;
+}
+.header__logo-search .search__suggestion__recent .recent__list > li {
+  display: flex;
+  justify-content: space-between;
+  padding-right: 20px;
 }
 
 .header__menu {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -428,7 +428,7 @@ a {
   letter-spacing: -1.15px;
   color: #222;
 }
-.header__logo-search .search__suggestion__similarwords li > a:hover {
+.header__logo-search .search__suggestion__similarwords li > a:hover, .header__logo-search .search__suggestion__similarwords a.selected {
   background-color: #f0f0f0;
 }
 .header__logo-search .search__suggestion__inner {

--- a/public/js/dataUtil.js
+++ b/public/js/dataUtil.js
@@ -1,0 +1,47 @@
+/**
+ * @param {String} urlPath
+ */
+// fetch data (json 데이터 반환)
+const fetchData = async (url) => {
+    try {
+        const res = await fetch(url);
+        return await res.json();
+    } catch (error) {
+        console.error(error);
+    }
+};
+
+// 캐시 스토리지에 캐시 데이터 등록
+const setCachedData = async (cacheName, url) => {
+    const cacheStorage = await caches.open(cacheName);
+    await cacheStorage.add(url);
+};
+
+// 캐시 스토리지에서 등록한 캐시 데이터 가져옴
+const getCachedData = async (cacheName, url, errorView = false) => {
+    try {
+        const cacheStorage = await caches.open(cacheName);
+        const cachedResponse = await cacheStorage.match(url);
+
+        if (!cachedResponse || !cachedResponse.ok)
+            throw new Error('[!] No cache data found..');
+
+        return await cachedResponse.json();
+    } catch (error) {
+        errorView && console.error(error);
+        return false;
+    }
+};
+
+// 캐시 스토리지 제거 (캐시 데이터 지우기)
+const setRemoveCacheStorage = async (cacheName) => {
+    const keys = await caches.keys();
+
+    for (const key of keys)
+        if (key === cacheName) {
+            caches.delete(key);
+            break;
+        }
+};
+
+export { fetchData, setCachedData, getCachedData, setRemoveCacheStorage };

--- a/public/js/index/MainController.js
+++ b/public/js/index/MainController.js
@@ -1,6 +1,7 @@
 // 이 컨트롤러는 상 하단 캐러셀 & 더보기 데이터 등을 포함하고 있음, 추후 분리하여 리팩토링 예정
 
-import _, {fetchData} from '../util.js';
+import _ from '../util.js';
+import {fetchData} from '../dataUtil.js';
 
 class MainController {
     constructor(indexWrappers, controlItems, carouselOptions) {

--- a/public/js/index/SearchController.js
+++ b/public/js/index/SearchController.js
@@ -61,52 +61,36 @@ SearchController.prototype.getAutoCompleteData = async function (inputValue) {
 // [3] visible 제어
 // 롤링 visible 제어
 SearchController.prototype.visibleRollingControl = function (searchInput = null) {
-    const inputValue = searchInput ? searchInput.value : _.$('input', this.searchBarWrapper).value;        
-    if (inputValue) 
-        _.forceToggleClass(this.searchBarRollingWrapper, 'visibility--hidden', true);
-    else
-        _.forceToggleClass(this.searchBarRollingWrapper, 'visibility--hidden', false);
+    const inputValue = searchInput ? searchInput.value : _.$('input', this.searchBarWrapper).value;
+    _.forceToggleClass(this.searchBarRollingWrapper, 'visibility--hidden', inputValue);            
 };
 
 // 인기 쇼핑 키워드 Visible 제어
 SearchController.prototype.visibleInnerControl = function (searchInput) {
     const similarWrapper = _.$('.similar__list', this.searchSuggestSimilarWrapper);
 
-    _.forceToggleClass(this.searchSuggestWrapper, 'visibility--hidden', false);
-    
-    if (searchInput.value) {                
-        (!similarWrapper.firstChild) && _.forceToggleClass(this.searchSuggestWrapper, 'visibility--hidden', true);
+    const suggestVisibleFlag = searchInput.value && !similarWrapper.firstChild;
+    _.forceToggleClass(this.searchSuggestWrapper, 'visibility--hidden', suggestVisibleFlag);
+    _.forceToggleClass(this.searchSuggestInnerWrapper, 'display--none', searchInput.value);    
+    _.forceToggleClass(this.searchSuggestSimilarWrapper, 'display--none', !searchInput.value);
 
-        _.forceToggleClass(this.searchSuggestInnerWrapper, 'display--none', true);    
-        _.forceToggleClass(this.searchSuggestSimilarWrapper, 'display--none', false); 
-    } else {
-        _.forceToggleClass(this.searchSuggestInnerWrapper, 'display--none', false);    
-        _.forceToggleClass(this.searchSuggestSimilarWrapper, 'display--none', true); 
-    }
 };
 
 // 자동완성 결과 및 인기 쇼핑 키워드 창 Visible 제어
 SearchController.prototype.visibleSuggestionControl = function (searchInput) { 
-    if (searchInput.value) {
-        // 검색창에 검색어가 있을 시 인기 쇼핑 키워드 창 false
-        _.forceToggleClass(this.searchSuggestInnerWrapper, 'display--none', true);        
-        _.forceToggleClass(this.searchSuggestSimilarWrapper, 'display--none', false);
-    } else {
-        // 검색창에 검색어가 없을 시 인기 쇼핑 키워드 창 true
-        _.forceToggleClass(this.searchSuggestInnerWrapper, 'display--none', false);        
-        _.forceToggleClass(this.searchSuggestSimilarWrapper, 'display--none', true);
-    }
+    // 검색창에 검색어가 있을 시 인기 쇼핑 키워드 창 false
+    // 검색창에 검색어가 없을 시 인기 쇼핑 키워드 창 true
+    _.forceToggleClass(this.searchSuggestInnerWrapper, 'display--none', searchInput.value);
+    _.forceToggleClass(this.searchSuggestSimilarWrapper, 'display--none', !searchInput.value);
 };
 
 // 검색창 자동완성 아이템 생성 / 제거 추적용 MutationObserver 설정 (init() 에서 설정해둠)
 SearchController.prototype.setAutoCompleteChangeDetection = function (searchSuggestSimilarWrapper, searchBarWrapper) {
     const similarWrapper = _.$('.similar__list', searchSuggestSimilarWrapper);
     const searchInput = _.$('input', searchBarWrapper);
-    const observer = new MutationObserver(() => {       
-        if (similarWrapper.childNodes.length > 0 || (!searchInput.value) ) 
-            _.forceToggleClass(this.searchSuggestWrapper, 'visibility--hidden', false)
-        else
-            _.forceToggleClass(this.searchSuggestWrapper, 'visibility--hidden', true);        
+    const observer = new MutationObserver(() => {               
+        const suggestVisibleFlag = !(similarWrapper.childNodes.length > 0 || !searchInput.value);
+        _.forceToggleClass(this.searchSuggestWrapper, 'visibility--hidden', suggestVisibleFlag);        
     });
 
     observer.observe(similarWrapper, {

--- a/public/js/util.js
+++ b/public/js/util.js
@@ -46,4 +46,7 @@ export const fetchData = async (url) => {
 export const delay = (ms, data = null) =>
     new Promise((resolve) => setTimeout(() => resolve(data), ms));
 
+export const isKorEngNum = (str) => /[a-zA-Z0-9ㄱ-힣]/gi.test(str);
+export const isPossibleInput = (str) => /Key|Numpad|Digit|Backspace/g.test(str);
+
 export default _;

--- a/public/js/util.js
+++ b/public/js/util.js
@@ -31,18 +31,6 @@ const _ = {
     },
 };
 
-/**
- * @param {String} urlPath
- */
-export const fetchData = async (url) => {
-    try {
-        const res = await fetch(url);
-        return await res.json();
-    } catch (error) {
-        console.error(error);
-    }
-};
-
 export const delay = (ms, data = null) =>
     new Promise((resolve) => setTimeout(() => resolve(data), ms));
 

--- a/public/sass/index.scss
+++ b/public/sass/index.scss
@@ -123,7 +123,7 @@
             color: #222;
         }
 
-        li > a:hover {
+        li > a:hover, a.selected {
             background-color: #f0f0f0;
         }
     }

--- a/public/sass/index.scss
+++ b/public/sass/index.scss
@@ -41,7 +41,7 @@
         padding: 2px 22px;
         position: relative;
 
-        input {
+        .search__input {
             color: $black;
             display: block;
             width: 95%;

--- a/public/sass/index.scss
+++ b/public/sass/index.scss
@@ -128,7 +128,7 @@
         }
     }
 
-    .search__suggestion__inner {
+    .search__suggestion__inner, .search__suggestion__recent {
         font-size: 13px;
 
         p {
@@ -140,14 +140,16 @@
             letter-spacing: $header-letterSpacing;
         }
 
-        .inner__list {
+        .inner__list, .recent__list {
             display: grid;
             grid-template-columns: repeat(2, 1fr);
             grid-template-rows: repeat(5, 1fr);
 
             grid-auto-flow: column;
         }
+    }
 
+    .search__suggestion__inner {
         .inner__list > li {
             overflow: hidden;
             height: 21px;
@@ -159,6 +161,14 @@
         li > span {
             margin-right: 10px;
             font-weight: 700;
+        }
+    }
+
+    .search__suggestion__recent {
+        .recent__list > li {
+            display: flex;
+            justify-content: space-between;
+            padding-right: 20px;
         }
     }
     // 미션 5 ------------------------------------------------------ END

--- a/public/sass/index/icon.scss
+++ b/public/sass/index/icon.scss
@@ -20,6 +20,10 @@
 }
 
 .wh {
+    &-8 {
+        width: 8px;
+        height: 8px;    
+    }
     &-23 {
         width: 23px;
         height: 23px;
@@ -108,5 +112,10 @@
         @extend .icon__comm2, .w-31, .h-18;
         background-position: 0 -850px;
         margin: 8px 4px 0 0;
+    }
+
+    &-remove {
+        @extend .icon__carousel, .wh-8;
+        background-position: -149.5px -57.5px;
     }
 }

--- a/views/index.html
+++ b/views/index.html
@@ -18,13 +18,14 @@
 
                     <div class="search">                        
                         <div class="search__bar">
-                            <input                            
+                            <input
                                 type="text"
-                                id="search"
+                                class="search__input"
                                 name="search"
-                                size="55"
-                                autocomplete="off"                                                                
-                            />                        
+                                autocomplete="off"                                
+                            />
+                            <input type="hidden" class="backup-value" value=''/>
+
                             <button type="button">
                                 <span class="i-search"></span>
                             </button>

--- a/views/index.html
+++ b/views/index.html
@@ -26,7 +26,7 @@
                             />
                             <input type="hidden" class="backup-value" value=''/>
 
-                            <button type="button">
+                            <button type="button" class="search__btn">
                                 <span class="i-search"></span>
                             </button>
 
@@ -41,9 +41,14 @@
                             </div>
 
                             <div class="search__suggestion__inner display--none">
-                                <p>인기 쇼핑 키워드</p>                                
+                                <p>인기 쇼핑 키워드</p>
                                 <ul class="inner__list"></ul>
-                            </div>  
+                            </div>
+
+                            <div class="search__suggestion__recent">
+                                <p>최근 검색어</p>
+                                <ul class="recent__list"></ul>
+                            </div>
                         </div>
                     </div>
 

--- a/views/index.html
+++ b/views/index.html
@@ -45,7 +45,7 @@
                                 <ul class="inner__list"></ul>
                             </div>
 
-                            <div class="search__suggestion__recent">
+                            <div class="search__suggestion__recent display--none">
                                 <p>최근 검색어</p>
                                 <ul class="recent__list"></ul>
                             </div>


### PR DESCRIPTION
### **쇼핑하우 SearchUI : Feature List**

**공통**

-   [x] 이전 코드 가져오기 (3주차 쇼핑하우)
-   [x] Prototype으로 개발 (Search UI 관련)
-   [x] 미션 3 코드 모두 async-await로 변경

**데이터**

-   [x] 데이터 만들어 두기 혹은 아마존에서 가져오기
    -   아마존에서 가져옴
-   [x] 동일하게 요청된 데이터는 캐시기능을 활용 (Cache Storage)

**검색**

-   [x] 평상시 검색창에선 인기 검색어 10개를 1개씩 롤링하며 보여주기
-   [x] 검색창 클릭 시, 인기 검색어 10개를 보여주기
-   [x] 글자를 입력했을 시 연관되는 키워드 보여주는 리스트 만들기
    -   [x] 검색어 입력했을 시 하단 리스트, div or ul
    -   [x] 검색어 추가 / 삭제시 모두.
    -   [x] 1초 이상 입력하지 않고 가만히 있을 때만 리스트 노출
        -   [x] debounce 활용하여 개발.
-   [x] 키보드 위 아래로 자동완성 글자가 선택되어 입력창에 보여짐

**추가구현 (최근 검색어)**

-   [x] 최근에 검색한 키워드 노출
-   [x] 특정 시간대 임의로 정하고 해당 시간대에서는 '인기검색어'가 아닌 '최근 검색어' 노출
-   [x] localStorage에 저장
-   [x] 항목별 삭제 기능

<hr/>

버그나 리팩토링 해야할 사항이 많지만.. 이제 다음주 주제를 생각해봐야겠습니다